### PR TITLE
Fix panics in block-id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-id"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/drifting-in-space/block-id"

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ fn main() {
     let generator = BlockId::new(Alphabet::alphanumeric(), seed, length);
     
     // Number to string.
-    assert_eq!("wjweA", &generator.encode_string(0));
-    assert_eq!("ZxJrE", &generator.encode_string(1));
-    assert_eq!("3e0IT", &generator.encode_string(2));
+    assert_eq!(Some("wjweA".to_string()), generator.encode_string(0));
+    assert_eq!(Some("ZxJrE".to_string()), generator.encode_string(1));
+    assert_eq!(Some("3e0IT".to_string()), generator.encode_string(2));
 
     // String to number.
-    assert_eq!(2, generator.decode_string("3e0IT"));
+    assert_eq!(Some(2), generator.decode_string("3e0IT"));
 }
 ```
 
@@ -62,21 +62,21 @@ fn main() {
     let generator = BlockId::new(alphabet, seed, length);
     
     // Now that we have a generator, we can turn numbers into short IDs.
-    assert_eq!("In4R", &generator.encode_string(0));
+    assert_eq!(Some("In4R".to_string()), generator.encode_string(0));
 
-    assert_eq!("4A7N", &generator.encode_string(440));
-    assert_eq!("tSp9", &generator.encode_string(441));
-    assert_eq!("6z6y", &generator.encode_string(442));
-    assert_eq!("ft0M", &generator.encode_string(443));
+    assert_eq!(Some("4A7N".to_string()), generator.encode_string(440));
+    assert_eq!(Some("tSp9".to_string()), generator.encode_string(441));
+    assert_eq!(Some("6z6y".to_string()), generator.encode_string(442));
+    assert_eq!(Some("ft0M".to_string()), generator.encode_string(443));
 
     // When we've exhausted all 4-digit codes, we simply move on to 5-digit codes.
-    assert_eq!("YeyKs", &generator.encode_string(123456789));
+    assert_eq!(Some("YeyKs".to_string()), generator.encode_string(123456789));
 
     // ...and so on.
-    assert_eq!("pFbrRf", &generator.encode_string(1234567890));
+    assert_eq!(Some("pFbrRf".to_string()), generator.encode_string(1234567890));
 
     // Codes are reversible, assuming we have the seed they were generated with.
-    assert_eq!(1234567890, generator.decode_string("pFbrRf"));
+    assert_eq!(Some(1234567890), generator.decode_string("pFbrRf"));
 }
 ```
 

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -89,12 +89,12 @@ impl<T: Copy + Hash + Eq> InvertableTransform for Alphabet<T> {
 
     type Output = T;
 
-    fn forward(&self, index: u8) -> T {
-        self.alphabet[index as usize]
+    fn forward(&self, index: u8) -> Option<T> {
+        self.alphabet.get(index as usize).copied()
     }
 
-    fn backward(&self, value: T) -> u8 {
-        self.inv_index[&value]
+    fn backward(&self, value: T) -> Option<u8> {
+        self.inv_index.get(&value).copied()
     }
 }
 
@@ -116,14 +116,22 @@ mod test {
     }
 
     #[test]
+    fn test_invalid_character() {
+        let chars = Alphabet::lowercase_alpha();
+        assert_eq!(None, chars.backward('!'));
+
+        assert_eq!(None, chars.forward(26));
+    }
+
+    #[test]
     fn test_forward() {
         let chars: Vec<char> = "abcdefghijklmnopqrstuvwxyz".chars().collect();
         let alpha = Alphabet::new(&chars);
 
         assert_eq!(26, alpha.len());
 
-        assert_eq!('a', alpha.forward(0));
-        assert_eq!('z', alpha.forward(25));
+        assert_eq!('a', alpha.forward(0).unwrap());
+        assert_eq!('z', alpha.forward(25).unwrap());
     }
 
     #[test]
@@ -131,8 +139,8 @@ mod test {
         let chars: Vec<char> = "abcdefghijklmnopqrstuvwxyz".chars().collect();
         let alpha = Alphabet::new(&chars);
 
-        assert_eq!(0, alpha.backward('a'));
-        assert_eq!(25, alpha.backward('z'));
+        assert_eq!(0, alpha.backward('a').unwrap());
+        assert_eq!(25, alpha.backward('z').unwrap());
     }
 
     #[test]
@@ -145,8 +153,8 @@ mod test {
         assert_eq!(52, alpha.len());
 
         for i in 0..chars.len() as u8 {
-            let c = alpha.forward(i);
-            let v = alpha.backward(c);
+            let c = alpha.forward(i).unwrap();
+            let v = alpha.backward(c).unwrap();
 
             assert_eq!(i, v);
         }

--- a/src/base.rs
+++ b/src/base.rs
@@ -21,7 +21,7 @@ impl InvertableTransform for BaseConversion {
     type Input = u64;
     type Output = Vec<u8>;
 
-    fn forward(&self, mut input: u64) -> Vec<u8> {
+    fn forward(&self, mut input: u64) -> Option<Vec<u8>> {
         let base = self.radix;
         let mut result = Vec::new();
 
@@ -36,10 +36,10 @@ impl InvertableTransform for BaseConversion {
 
         result.reverse();
 
-        result
+        Some(result)
     }
 
-    fn backward(&self, data: Vec<u8>) -> u64 {
+    fn backward(&self, data: Vec<u8>) -> Option<u64> {
         let mut result: u64 = 0;
         let base = self.radix;
 
@@ -50,7 +50,7 @@ impl InvertableTransform for BaseConversion {
             result += *b as u64;
         }
 
-        result
+        Some(result)
     }
 }
 
@@ -62,26 +62,38 @@ mod test {
 
     #[test]
     fn test_base_convert() {
-        assert_eq!(vec![5], BaseConversion::new(128).forward(5));
+        assert_eq!(vec![5], BaseConversion::new(128).forward(5).unwrap());
 
-        assert_eq!(vec![1, 0, 1, 0], BaseConversion::new(2).forward(10));
+        assert_eq!(
+            vec![1, 0, 1, 0],
+            BaseConversion::new(2).forward(10).unwrap()
+        );
 
-        assert_eq!(vec![1, 0, 1], BaseConversion::new(3).forward(10));
-        assert_eq!(vec![1, 0, 2], BaseConversion::new(3).forward(11));
-        assert_eq!(vec![1, 1, 0], BaseConversion::new(3).forward(12));
-        assert_eq!(vec![1, 0, 0, 0], BaseConversion::new(3).forward(27));
+        assert_eq!(vec![1, 0, 1], BaseConversion::new(3).forward(10).unwrap());
+        assert_eq!(vec![1, 0, 2], BaseConversion::new(3).forward(11).unwrap());
+        assert_eq!(vec![1, 1, 0], BaseConversion::new(3).forward(12).unwrap());
+        assert_eq!(
+            vec![1, 0, 0, 0],
+            BaseConversion::new(3).forward(27).unwrap()
+        );
     }
 
     #[test]
     fn test_base_invert() {
-        assert_eq!(5, BaseConversion::new(128).backward(vec![5]));
+        assert_eq!(5, BaseConversion::new(128).backward(vec![5]).unwrap());
 
-        assert_eq!(10, BaseConversion::new(2).backward(vec![1, 0, 1, 0]));
+        assert_eq!(
+            10,
+            BaseConversion::new(2).backward(vec![1, 0, 1, 0]).unwrap()
+        );
 
-        assert_eq!(10, BaseConversion::new(3).backward(vec![1, 0, 1]));
-        assert_eq!(11, BaseConversion::new(3).backward(vec![1, 0, 2]));
-        assert_eq!(12, BaseConversion::new(3).backward(vec![1, 1, 0]));
-        assert_eq!(27, BaseConversion::new(3).backward(vec![1, 0, 0, 0]));
+        assert_eq!(10, BaseConversion::new(3).backward(vec![1, 0, 1]).unwrap());
+        assert_eq!(11, BaseConversion::new(3).backward(vec![1, 0, 2]).unwrap());
+        assert_eq!(12, BaseConversion::new(3).backward(vec![1, 1, 0]).unwrap());
+        assert_eq!(
+            27,
+            BaseConversion::new(3).backward(vec![1, 0, 0, 0]).unwrap()
+        );
     }
 
     #[test]

--- a/src/cascade.rs
+++ b/src/cascade.rs
@@ -19,7 +19,7 @@ impl InvertableTransform for Cascade {
 
     type Output = Vec<u8>;
 
-    fn forward(&self, mut input: Vec<u8>) -> Vec<u8> {
+    fn forward(&self, mut input: Vec<u8>) -> Option<Vec<u8>> {
         let mut last = 0;
 
         for v in input.iter_mut() {
@@ -27,10 +27,10 @@ impl InvertableTransform for Cascade {
             last = *v;
         }
 
-        input
+        Some(input)
     }
 
-    fn backward(&self, mut output: Vec<u8>) -> Vec<u8> {
+    fn backward(&self, mut output: Vec<u8>) -> Option<Vec<u8>> {
         let mut last = 0;
 
         for v in output.iter_mut() {
@@ -39,7 +39,7 @@ impl InvertableTransform for Cascade {
             last = tmp;
         }
 
-        output
+        Some(output)
     }
 }
 
@@ -56,7 +56,7 @@ mod test {
             let input = vec![16, 16, 25];
             let expected = vec![16, 6, 5];
 
-            assert_eq!(expected, cascade.forward(input));
+            assert_eq!(expected, cascade.forward(input).unwrap());
         }
 
         {
@@ -64,7 +64,7 @@ mod test {
             let input = vec![5, 9, 120, 5, 7, 15];
             let expected = vec![5, 14, 11, 16, 23, 38];
 
-            assert_eq!(expected, cascade.forward(input));
+            assert_eq!(expected, cascade.forward(input).unwrap());
         }
     }
 
@@ -74,7 +74,7 @@ mod test {
         let input = vec![5, 9, 120, 5, 7, 15];
         let expected = vec![5, 14, 11, 16, 23, 38];
 
-        assert_eq!(input, cascade.backward(expected));
+        assert_eq!(input, cascade.backward(expected).unwrap());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl BlockId<char> {
 
     /// Decode a `u64` from an opaque string.
     pub fn decode_string(&self, v: &str) -> Option<u64> {
-        Some(self.backward(v.chars().collect())?)
+        self.backward(v.chars().collect())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,10 @@ fn main() {
     let mut i: u64 = 1;
 
     loop {
-        let code = permuter.encode_string(i);
+        let code = permuter.encode_string(i).unwrap();
         println!("{}: {}", i, code);
 
-        let result = permuter.decode_string(&code);
+        let result = permuter.decode_string(&code).unwrap();
         assert_eq!(i, result);
 
         i += 1;

--- a/src/permutation.rs
+++ b/src/permutation.rs
@@ -41,12 +41,12 @@ impl InvertableTransform for Permutation {
     type Input = u8;
     type Output = u8;
 
-    fn forward(&self, v: u8) -> u8 {
-        self.forward[v as usize]
+    fn forward(&self, v: u8) -> Option<u8> {
+        self.forward.get(v as usize).copied()
     }
 
-    fn backward(&self, v: u8) -> u8 {
-        self.inverse[v as usize]
+    fn backward(&self, v: u8) -> Option<u8> {
+        self.inverse.get(v as usize).copied()
     }
 }
 
@@ -69,15 +69,15 @@ mod tests {
     fn test_permutation() {
         let perm = Permutation::new(vec![3, 1, 0, 2]);
 
-        assert_eq!(3, perm.forward(0));
-        assert_eq!(1, perm.forward(1));
-        assert_eq!(0, perm.forward(2));
-        assert_eq!(2, perm.forward(3));
+        assert_eq!(3, perm.forward(0).unwrap());
+        assert_eq!(1, perm.forward(1).unwrap());
+        assert_eq!(0, perm.forward(2).unwrap());
+        assert_eq!(2, perm.forward(3).unwrap());
 
-        assert_eq!(0, perm.backward(3));
-        assert_eq!(1, perm.backward(1));
-        assert_eq!(2, perm.backward(0));
-        assert_eq!(3, perm.backward(2));
+        assert_eq!(1, perm.backward(1).unwrap());
+        assert_eq!(0, perm.backward(3).unwrap());
+        assert_eq!(2, perm.backward(0).unwrap());
+        assert_eq!(3, perm.backward(2).unwrap());
     }
 
     #[test]

--- a/src/permute.rs
+++ b/src/permute.rs
@@ -20,18 +20,18 @@ impl InvertableTransform for Permute {
     type Input = Vec<u8>;
     type Output = Vec<u8>;
 
-    fn forward(&self, mut input: Vec<u8>) -> Vec<u8> {
+    fn forward(&self, mut input: Vec<u8>) -> Option<Vec<u8>> {
         for elem in input.iter_mut() {
-            *elem = self.permutation.forward(*elem);
+            *elem = self.permutation.forward(*elem)?;
         }
-        input
+        Some(input)
     }
 
-    fn backward(&self, mut output: Vec<u8>) -> Vec<u8> {
+    fn backward(&self, mut output: Vec<u8>) -> Option<Vec<u8>> {
         for elem in output.iter_mut() {
-            *elem = self.permutation.backward(*elem);
+            *elem = self.permutation.backward(*elem)?;
         }
-        output
+        Some(output)
     }
 }
 

--- a/src/rotate.rs
+++ b/src/rotate.rs
@@ -19,14 +19,14 @@ impl<T> InvertableTransform for Rotate<T> {
     type Input = Vec<T>;
     type Output = Vec<T>;
 
-    fn forward(&self, mut value: Vec<T>) -> Vec<T> {
+    fn forward(&self, mut value: Vec<T>) -> Option<Vec<T>> {
         value.rotate_left(1);
-        value
+        Some(value)
     }
 
-    fn backward(&self, mut value: Vec<T>) -> Vec<T> {
+    fn backward(&self, mut value: Vec<T>) -> Option<Vec<T>> {
         value.rotate_right(1);
-        value
+        Some(value)
     }
 }
 
@@ -40,7 +40,7 @@ mod test {
         let before = vec![4, 5, 6, 7, 8];
         let after = vec![5, 6, 7, 8, 4];
 
-        assert_eq!(after.clone(), rot.forward(before.clone()));
-        assert_eq!(before, rot.backward(after));
+        assert_eq!(after.clone(), rot.forward(before.clone()).unwrap());
+        assert_eq!(before, rot.backward(after).unwrap());
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -2,9 +2,9 @@ pub trait InvertableTransform {
     type Input;
     type Output;
 
-    fn forward(&self, input: Self::Input) -> Self::Output;
+    fn forward(&self, input: Self::Input) -> Option<Self::Output>;
 
-    fn backward(&self, output: Self::Output) -> Self::Input;
+    fn backward(&self, output: Self::Output) -> Option<Self::Input>;
 }
 
 #[cfg(test)]
@@ -16,8 +16,8 @@ pub mod test {
     where
         T::Input: PartialEq + Debug + Clone,
     {
-        let output = transform.forward(value.clone());
-        let result = transform.backward(output);
+        let output = transform.forward(value.clone()).unwrap();
+        let result = transform.backward(output).unwrap();
 
         assert_eq!(result, value, "Input was not the same after a round trip.");
     }


### PR DESCRIPTION
This changes the interface of BlockId to return `Option` instead of non-nullable values. If we attempt to convert a block ID with characters not in the alphabet, it will return `None`.

This is an API change, so I've bumped the minor version (semver has an exception when the major version is 0 to allow breaking API changes without a major version bump).